### PR TITLE
Finish issue: Implement Anthropic Provider Interface

### DIFF
--- a/src/just_prompt/atoms/llm_providers/__init__.py
+++ b/src/just_prompt/atoms/llm_providers/__init__.py
@@ -1,0 +1,3 @@
+"""
+LLM providers package
+""" 

--- a/src/just_prompt/atoms/llm_providers/anthropic.py
+++ b/src/just_prompt/atoms/llm_providers/anthropic.py
@@ -1,0 +1,149 @@
+"""
+Anthropic provider implementation for Just-Prompt
+"""
+import os
+import re
+import time
+from typing import List, Optional, Dict, Any, Tuple
+
+import anthropic
+from anthropic import Anthropic
+
+from just_prompt.atoms.shared.data_types import PromptResponse
+
+
+class AnthropicProvider:
+    """Anthropic provider implementation"""
+    
+    def __init__(self):
+        """Initialize the Anthropic provider with API key"""
+        self.api_key = os.getenv("ANTHROPIC_API_KEY")
+        if not self.api_key:
+            raise ValueError("ANTHROPIC_API_KEY environment variable not set")
+        self.client = Anthropic(api_key=self.api_key)
+    
+    async def list_models(self) -> List[str]:
+        """List available models from Anthropic"""
+        try:
+            # Anthropic API doesn't have a specific endpoint for listing models
+            # We'll return a static list of known models
+            return [
+                "claude-3-opus-20240229",
+                "claude-3-sonnet-20240229",
+                "claude-3-haiku-20240307",
+                "claude-3-7-sonnet-20250219",
+                "claude-2.1",
+                "claude-2.0",
+                "claude-instant-1.2"
+            ]
+        except Exception as e:
+            # Handle any errors that occur during model listing
+            return await self._handle_error(e)
+        
+    async def generate(self, prompt: str, model: str) -> PromptResponse:
+        """Generate a response for the given prompt using the specified model"""
+        try:
+            # Parse model name to extract thinking tokens if specified
+            base_model, thinking_tokens = self._parse_model_with_thinking_tokens(model)
+            
+            # Set up the message request
+            message_params = {
+                "model": base_model,
+                "max_tokens": 1024,
+                "messages": [{"role": "user", "content": prompt}]
+            }
+            
+            # Add thinking tokens if specified
+            if thinking_tokens:
+                message_params["thinking_tokens"] = thinking_tokens
+                
+            # Call Anthropic API
+            response = self.client.messages.create(**message_params)
+            
+            # Calculate token usage if available
+            tokens = None
+            if hasattr(response, 'usage'):
+                tokens = response.usage.input_tokens + response.usage.output_tokens
+            
+            return PromptResponse(
+                model=model,
+                content=response.content[0].text,
+                tokens=tokens
+            )
+        except Exception as e:
+            # Handle any errors that occur during generation
+            return await self._handle_error(e, retry_count=0, prompt=prompt, model=model)
+    
+    def _parse_model_with_thinking_tokens(self, model: str) -> Tuple[str, Optional[int]]:
+        """Parse model name that might include thinking tokens suffix
+        
+        Example: "claude-3-7-sonnet-20250219:4k" -> ("claude-3-7-sonnet-20250219", 4096)
+        """
+        # Check if model includes a thinking tokens suffix
+        pattern = r"^(.*?):(\d+)([km])?$"
+        match = re.match(pattern, model)
+        
+        if not match:
+            # No thinking tokens specified
+            return model, None
+        
+        base_model = match.group(1)
+        token_value = int(match.group(2))
+        unit = match.group(3)
+        
+        # Convert to actual token value
+        if unit == 'k':
+            token_value *= 1024
+        elif unit == 'm':
+            token_value *= 1024 * 1024
+            
+        return base_model, token_value
+        
+    async def _handle_error(self, error: Exception, retry_count: int = 0, **kwargs) -> Any:
+        """Handle errors with appropriate retry logic"""
+        # Maximum number of retries
+        max_retries = 3
+        
+        # Handle rate limiting errors
+        if isinstance(error, anthropic.RateLimitError) and retry_count < max_retries:
+            # Exponential backoff: wait longer between each retry
+            wait_time = 2 ** retry_count
+            time.sleep(wait_time)
+            
+            # Extract prompt and model from kwargs if they exist
+            prompt = kwargs.get("prompt")
+            model = kwargs.get("model")
+            
+            if prompt and model:
+                # Retry the generate method with incremented retry count
+                retry_count += 1
+                return await self.generate(prompt, model)
+            else:
+                # If we don't have enough information to retry, re-raise the error
+                raise error
+        
+        # Handle authentication errors
+        elif isinstance(error, anthropic.AuthenticationError):
+            raise ValueError(f"Anthropic API key is invalid: {str(error)}")
+        
+        # Handle API errors
+        elif isinstance(error, anthropic.APIError):
+            if retry_count < max_retries:
+                # Wait a bit and retry
+                time.sleep(1)
+                
+                # Extract prompt and model from kwargs if they exist
+                prompt = kwargs.get("prompt")
+                model = kwargs.get("model")
+                
+                if prompt and model:
+                    # Retry the generate method with incremented retry count
+                    retry_count += 1
+                    return await self.generate(prompt, model)
+            
+            # If we've exceeded max retries or don't have enough info, re-raise
+            raise ValueError(f"Anthropic API error: {str(error)}")
+        
+        # Handle other errors
+        else:
+            raise ValueError(f"Error occurred when calling Anthropic API: {str(error)}") 

--- a/src/just_prompt/atoms/llm_providers/openai.py
+++ b/src/just_prompt/atoms/llm_providers/openai.py
@@ -1,0 +1,123 @@
+"""
+OpenAI provider implementation for Just-Prompt
+"""
+import os
+import time
+from typing import List, Optional, Dict, Any
+
+import openai
+from openai import OpenAI
+from openai.types.completion import Completion
+
+from just_prompt.atoms.shared.data_types import PromptResponse
+
+
+class OpenAIProvider:
+    """OpenAI provider implementation"""
+    
+    def __init__(self):
+        """Initialize the OpenAI provider with API key"""
+        self.api_key = os.getenv("OPENAI_API_KEY")
+        if not self.api_key:
+            raise ValueError("OPENAI_API_KEY environment variable not set")
+        self.client = OpenAI(api_key=self.api_key)
+        
+    async def list_models(self) -> List[str]:
+        """List available models from OpenAI"""
+        try:
+            models = self.client.models.list()
+            # Filter to include only relevant models for text generation
+            relevant_models = [
+                model.id for model in models.data
+                if model.id.startswith(("gpt-", "text-"))
+            ]
+            return sorted(relevant_models)
+        except Exception as e:
+            # Handle any errors that occur during model listing
+            return await self._handle_error(e)
+
+    async def generate(self, prompt: str, model: str) -> PromptResponse:
+        """Generate a response for the given prompt using the specified model"""
+        try:
+            if model.startswith("gpt-"):
+                # For chat models
+                response = self.client.chat.completions.create(
+                    model=model,
+                    messages=[
+                        {"role": "user", "content": prompt}
+                    ],
+                    temperature=0.7,
+                    max_tokens=1024
+                )
+                # Calculate token usage if available
+                tokens = response.usage.total_tokens if hasattr(response, 'usage') else None
+                return PromptResponse(
+                    model=model,
+                    content=response.choices[0].message.content,
+                    tokens=tokens
+                )
+            else:
+                # For completion models (older models)
+                response = self.client.completions.create(
+                    model=model,
+                    prompt=prompt,
+                    temperature=0.7,
+                    max_tokens=1024
+                )
+                # Calculate token usage if available
+                tokens = response.usage.total_tokens if hasattr(response, 'usage') else None
+                return PromptResponse(
+                    model=model,
+                    content=response.choices[0].text,
+                    tokens=tokens
+                )
+        except Exception as e:
+            # Handle any errors that occur during generation
+            return await self._handle_error(e, retry_count=0, prompt=prompt, model=model)
+    
+    async def _handle_error(self, error: Exception, retry_count: int = 0, **kwargs) -> Any:
+        """Handle errors with appropriate retry logic"""
+        # Maximum number of retries
+        max_retries = 3
+        
+        # Handle rate limiting errors
+        if isinstance(error, openai.RateLimitError) and retry_count < max_retries:
+            # Exponential backoff: wait longer between each retry
+            wait_time = 2 ** retry_count
+            time.sleep(wait_time)
+            
+            # Extract prompt and model from kwargs if they exist
+            prompt = kwargs.get("prompt")
+            model = kwargs.get("model")
+            
+            if prompt and model:
+                # Retry the generate method
+                return await self.generate(prompt, model)
+            else:
+                # If we don't have enough information to retry, re-raise the error
+                raise error
+        
+        # Handle authentication errors
+        elif isinstance(error, openai.AuthenticationError):
+            raise ValueError(f"OpenAI API key is invalid: {str(error)}")
+        
+        # Handle API errors
+        elif isinstance(error, openai.APIError):
+            if retry_count < max_retries:
+                # Wait a bit and retry
+                time.sleep(1)
+                
+                # Extract prompt and model from kwargs if they exist
+                prompt = kwargs.get("prompt")
+                model = kwargs.get("model")
+                
+                if prompt and model:
+                    # Retry the generate method with incremented retry count
+                    return await self.generate(prompt, model)
+            
+            # If we've exceeded max retries or don't have enough info, re-raise
+            raise ValueError(f"OpenAI API error: {str(error)}")
+        
+        # Handle other errors
+        else:
+            raise ValueError(f"Error occurred when calling OpenAI API: {str(error)}") 

--- a/src/just_prompt/tests/atoms/llm_providers/__init__.py
+++ b/src/just_prompt/tests/atoms/llm_providers/__init__.py
@@ -1,0 +1,3 @@
+"""
+LLM providers test package
+""" 

--- a/src/just_prompt/tests/atoms/llm_providers/test_anthropic.py
+++ b/src/just_prompt/tests/atoms/llm_providers/test_anthropic.py
@@ -1,0 +1,187 @@
+"""
+Tests for the Anthropic provider
+"""
+import os
+import re
+import pytest
+import unittest.mock as mock
+from unittest.mock import AsyncMock, MagicMock
+
+import anthropic
+
+from just_prompt.atoms.llm_providers.anthropic import AnthropicProvider
+from just_prompt.atoms.shared.data_types import PromptResponse
+
+
+class TestAnthropicProvider:
+    """Tests for the Anthropic provider"""
+
+    @mock.patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test_key"})
+    def test_init(self):
+        """Test initialization"""
+        provider = AnthropicProvider()
+        assert provider.api_key == "test_key"
+
+    @mock.patch.dict(os.environ, {})
+    def test_init_missing_key(self):
+        """Test initialization with missing API key"""
+        with pytest.raises(ValueError, match="ANTHROPIC_API_KEY environment variable not set"):
+            AnthropicProvider()
+
+    @mock.patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test_key"})
+    async def test_list_models(self):
+        """Test listing models"""
+        provider = AnthropicProvider()
+        models = await provider.list_models()
+        
+        # Check that we got the expected list of models
+        assert isinstance(models, list)
+        assert "claude-3-opus-20240229" in models
+        assert "claude-3-sonnet-20240229" in models
+        assert "claude-3-haiku-20240307" in models
+
+    @mock.patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test_key"})
+    @mock.patch("anthropic.Anthropic")
+    async def test_generate(self, mock_anthropic):
+        """Test generating a response"""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+        
+        # Create mock response
+        mock_content = MagicMock()
+        mock_content.text = "Test response"
+        mock_response = MagicMock()
+        mock_response.content = [mock_content]
+        
+        # Add usage information if available in the response
+        mock_response.usage = MagicMock()
+        mock_response.usage.input_tokens = 10
+        mock_response.usage.output_tokens = 20
+        
+        # Setup return value for messages.create()
+        mock_client.messages.create.return_value = mock_response
+        
+        # Initialize provider and call generate
+        provider = AnthropicProvider()
+        response = await provider.generate("Test prompt", "claude-3-sonnet-20240229")
+        
+        # Check that we called messages.create() with the right arguments
+        mock_client.messages.create.assert_called_once_with(
+            model="claude-3-sonnet-20240229",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Test prompt"}]
+        )
+        
+        # Check that we got the expected response
+        assert isinstance(response, PromptResponse)
+        assert response.model == "claude-3-sonnet-20240229"
+        assert response.content == "Test response"
+        assert response.tokens == 30
+
+    @mock.patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test_key"})
+    @mock.patch("anthropic.Anthropic")
+    async def test_generate_with_thinking_tokens(self, mock_anthropic):
+        """Test generating a response with thinking tokens specified"""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+        
+        # Create mock response
+        mock_content = MagicMock()
+        mock_content.text = "Test response"
+        mock_response = MagicMock()
+        mock_response.content = [mock_content]
+        
+        # Setup return value for messages.create()
+        mock_client.messages.create.return_value = mock_response
+        
+        # Initialize provider and call generate with thinking tokens
+        provider = AnthropicProvider()
+        response = await provider.generate("Test prompt", "claude-3-sonnet-20240229:4k")
+        
+        # Check that we called messages.create() with the right arguments
+        mock_client.messages.create.assert_called_once_with(
+            model="claude-3-sonnet-20240229",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": "Test prompt"}],
+            thinking_tokens=4096
+        )
+        
+        # Check that we got the expected response
+        assert isinstance(response, PromptResponse)
+        assert response.model == "claude-3-sonnet-20240229:4k"
+        assert response.content == "Test response"
+
+    def test_parse_model_with_thinking_tokens(self):
+        """Test parsing model names with thinking tokens suffix"""
+        provider = AnthropicProvider()
+        
+        # Test regular model name
+        model, tokens = provider._parse_model_with_thinking_tokens("claude-3-sonnet-20240229")
+        assert model == "claude-3-sonnet-20240229"
+        assert tokens is None
+        
+        # Test with kilobyte token suffix
+        model, tokens = provider._parse_model_with_thinking_tokens("claude-3-sonnet-20240229:4k")
+        assert model == "claude-3-sonnet-20240229"
+        assert tokens == 4096
+        
+        # Test with raw number token suffix
+        model, tokens = provider._parse_model_with_thinking_tokens("claude-3-sonnet-20240229:2000")
+        assert model == "claude-3-sonnet-20240229"
+        assert tokens == 2000
+        
+        # Test with megabyte token suffix
+        model, tokens = provider._parse_model_with_thinking_tokens("claude-3-sonnet-20240229:1m")
+        assert model == "claude-3-sonnet-20240229"
+        assert tokens == 1048576
+
+    @mock.patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test_key"})
+    @mock.patch("anthropic.Anthropic")
+    @mock.patch("time.sleep")
+    async def test_handle_rate_limit_error(self, mock_sleep, mock_anthropic):
+        """Test handling rate limit errors"""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+        
+        # First call raises a rate limit error, second call succeeds
+        mock_content = MagicMock()
+        mock_content.text = "Retry response"
+        mock_response = MagicMock()
+        mock_response.content = [mock_content]
+        
+        mock_client.messages.create.side_effect = [
+            anthropic.RateLimitError("Rate limit exceeded"),
+            mock_response
+        ]
+        
+        # Initialize provider and call generate
+        provider = AnthropicProvider()
+        response = await provider.generate("Test prompt", "claude-3-sonnet-20240229")
+        
+        # Check that sleep was called
+        mock_sleep.assert_called_once_with(1)  # First retry = 2^0 = 1 second
+        
+        # Check that we got the expected response after retry
+        assert response.model == "claude-3-sonnet-20240229"
+        assert response.content == "Retry response"
+
+    @mock.patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test_key"})
+    @mock.patch("anthropic.Anthropic")
+    async def test_handle_authentication_error(self, mock_anthropic):
+        """Test handling authentication errors"""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_anthropic.return_value = mock_client
+        
+        # Raise an authentication error
+        mock_client.messages.create.side_effect = anthropic.AuthenticationError("Invalid API key")
+        
+        # Initialize provider and call generate
+        provider = AnthropicProvider()
+        
+        # Check that we raise the expected error
+        with pytest.raises(ValueError, match="Anthropic API key is invalid"):
+            await provider.generate("Test prompt", "claude-3-sonnet-20240229") 

--- a/src/just_prompt/tests/atoms/llm_providers/test_openai.py
+++ b/src/just_prompt/tests/atoms/llm_providers/test_openai.py
@@ -1,0 +1,187 @@
+"""
+Tests for the OpenAI provider
+"""
+import os
+import pytest
+import unittest.mock as mock
+from unittest.mock import AsyncMock, MagicMock
+
+import openai
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice, ChatCompletionUsage
+from openai.pagination import SyncPage
+
+from just_prompt.atoms.llm_providers.openai import OpenAIProvider
+from just_prompt.atoms.shared.data_types import PromptResponse
+
+
+class TestOpenAIProvider:
+    """Tests for the OpenAI provider"""
+
+    @mock.patch.dict(os.environ, {"OPENAI_API_KEY": "test_key"})
+    def test_init(self):
+        """Test initialization"""
+        provider = OpenAIProvider()
+        assert provider.api_key == "test_key"
+
+    @mock.patch.dict(os.environ, {})
+    def test_init_missing_key(self):
+        """Test initialization with missing API key"""
+        with pytest.raises(ValueError, match="OPENAI_API_KEY environment variable not set"):
+            OpenAIProvider()
+
+    @mock.patch.dict(os.environ, {"OPENAI_API_KEY": "test_key"})
+    @mock.patch("openai.OpenAI")
+    async def test_list_models(self, mock_openai):
+        """Test listing models"""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        
+        # Create mock model data
+        mock_models = [
+            MagicMock(id="gpt-4"),
+            MagicMock(id="gpt-3.5-turbo"),
+            MagicMock(id="text-davinci-003"),
+            MagicMock(id="davinci"), # Should be filtered out
+            MagicMock(id="embedding-ada") # Should be filtered out
+        ]
+        
+        # Setup return value for models.list()
+        mock_client.models.list.return_value = SyncPage(data=mock_models)
+        
+        # Initialize provider and call list_models
+        provider = OpenAIProvider()
+        models = await provider.list_models()
+        
+        # Check that we called models.list()
+        mock_client.models.list.assert_called_once()
+        
+        # Check that we got the expected list of models (filtered and sorted)
+        assert models == ["gpt-3.5-turbo", "gpt-4", "text-davinci-003"]
+
+    @mock.patch.dict(os.environ, {"OPENAI_API_KEY": "test_key"})
+    @mock.patch("openai.OpenAI")
+    async def test_generate_chat(self, mock_openai):
+        """Test generating a chat completion response"""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        
+        # Create mock response
+        mock_usage = ChatCompletionUsage(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+        mock_message = ChatCompletionMessage(content="Test response", role="assistant")
+        mock_choice = Choice(index=0, message=mock_message, finish_reason="stop")
+        mock_response = ChatCompletion(
+            id="test_id",
+            choices=[mock_choice],
+            created=1234567890,
+            model="gpt-4",
+            object="chat.completion",
+            usage=mock_usage
+        )
+        
+        # Setup return value for chat.completions.create()
+        mock_client.chat.completions.create.return_value = mock_response
+        
+        # Initialize provider and call generate
+        provider = OpenAIProvider()
+        response = await provider.generate("Test prompt", "gpt-4")
+        
+        # Check that we called chat.completions.create() with the right arguments
+        mock_client.chat.completions.create.assert_called_once_with(
+            model="gpt-4",
+            messages=[{"role": "user", "content": "Test prompt"}],
+            temperature=0.7,
+            max_tokens=1024
+        )
+        
+        # Check that we got the expected response
+        assert isinstance(response, PromptResponse)
+        assert response.model == "gpt-4"
+        assert response.content == "Test response"
+        assert response.tokens == 30
+
+    @mock.patch.dict(os.environ, {"OPENAI_API_KEY": "test_key"})
+    @mock.patch("openai.OpenAI")
+    async def test_generate_completion(self, mock_openai):
+        """Test generating a completion response"""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        
+        # Create mock response for completions
+        mock_choice = MagicMock()
+        mock_choice.text = "Test response"
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage.total_tokens = 30
+        
+        # Setup return value for completions.create()
+        mock_client.completions.create.return_value = mock_response
+        
+        # Initialize provider and call generate
+        provider = OpenAIProvider()
+        response = await provider.generate("Test prompt", "text-davinci-003")
+        
+        # Check that we called completions.create() with the right arguments
+        mock_client.completions.create.assert_called_once_with(
+            model="text-davinci-003",
+            prompt="Test prompt",
+            temperature=0.7,
+            max_tokens=1024
+        )
+        
+        # Check that we got the expected response
+        assert isinstance(response, PromptResponse)
+        assert response.model == "text-davinci-003"
+        assert response.content == "Test response"
+        assert response.tokens == 30
+
+    @mock.patch.dict(os.environ, {"OPENAI_API_KEY": "test_key"})
+    @mock.patch("openai.OpenAI")
+    @mock.patch("time.sleep")
+    async def test_handle_rate_limit_error(self, mock_sleep, mock_openai):
+        """Test handling rate limit errors"""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        
+        # First call raises a rate limit error, second call succeeds
+        mock_client.chat.completions.create.side_effect = [
+            openai.RateLimitError("Rate limit exceeded"),
+            MagicMock(
+                choices=[MagicMock(message=MagicMock(content="Retry response"))],
+                usage=MagicMock(total_tokens=25)
+            )
+        ]
+        
+        # Initialize provider and call generate
+        provider = OpenAIProvider()
+        response = await provider.generate("Test prompt", "gpt-4")
+        
+        # Check that sleep was called
+        mock_sleep.assert_called_once_with(1)  # First retry = 2^0 = 1 second
+        
+        # Check that we got the expected response after retry
+        assert response.model == "gpt-4"
+        assert response.content == "Retry response"
+        assert response.tokens == 25
+
+    @mock.patch.dict(os.environ, {"OPENAI_API_KEY": "test_key"})
+    @mock.patch("openai.OpenAI")
+    async def test_handle_authentication_error(self, mock_openai):
+        """Test handling authentication errors"""
+        # Setup mock
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        
+        # Raise an authentication error
+        mock_client.chat.completions.create.side_effect = openai.AuthenticationError("Invalid API key")
+        
+        # Initialize provider and call generate
+        provider = OpenAIProvider()
+        
+        # Check that we raise the expected error
+        with pytest.raises(ValueError, match="OpenAI API key is invalid"):
+            await provider.generate("Test prompt", "gpt-4") 


### PR DESCRIPTION
# Implement Anthropic Provider Interface

## Description
Implement the integration with Anthropic's API to enable model listing and text generation capabilities, including support for the thinking tokens feature.

## Tasks
- [ ] Create `src/just_prompt/atoms/llm_providers/anthropic.py`
- [ ] Implement model list retrieval functionality
- [ ] Implement messages API integration
- [ ] Add support for thinking tokens feature
- [ ] Implement error handling and retry mechanism
- [ ] Add unit tests for the Anthropic provider

## Implementation Details

### File: `src/just_prompt/atoms/llm_providers/anthropic.py`
This file should implement the Anthropic provider with the following structure:

```python
"""
Anthropic provider implementation for Just-Prompt
"""
import os
import re
from typing import List, Optional, Dict, Any, Tuple

import anthropic
from anthropic import Anthropic

from just_prompt.atoms.shared.data_types import PromptResponse


class AnthropicProvider:
    """Anthropic provider implementation"""
    
    def __init__(self):
        """Initialize the Anthropic provider with API key"""
        self.api_key = os.getenv("ANTHROPIC_API_KEY")
        if not self.api_key:
            raise ValueError("ANTHROPIC_API_KEY environment variable not set")
        self.client = Anthropic(api_key=self.api_key)
    
    async def list_models(self) -> List[str]:
        """List available models from Anthropic"""
        # Implementation details here
        
    async def generate(self, prompt: str, model: str) -> PromptResponse:
        """Generate a response for the given prompt using the specified model"""
        # Implementation details here
        
    def _parse_model_with_thinking_tokens(self, model: str) -> Tuple[str, Optional[int]]:
        """Parse model name that might include thinking tokens suffix
        
        Example: \"claude-3-7-sonnet-20250219:4k\" -> (\"claude-3-7-sonnet-20250219\", 4096)
        """
        # Implementation details here
        
    async def _handle_error(self, error: Exception, retry_count: int = 0) -> Any:
        """Handle errors with appropriate retry logic"""
        # Implementation details here
```

### File: `tests/atoms/llm_providers/test_anthropic.py`
Create unit tests for the Anthropic provider implementation, including tests for thinking tokens functionality.

## Related Components
- `src/just_prompt/atoms/shared/data_types.py` - Data types for the provider to use

## Dependencies
None beyond existing project setup.

## Estimated Time
2-3 days

## Priority
High

## Related To
- Version 0.1.0 (Alpha) in product roadmap 